### PR TITLE
Add dependency on ledger-mode

### DIFF
--- a/evil-ledger.el
+++ b/evil-ledger.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/atheriel/evil-ledger
 ;; Keywords: convenience evil languages ledger vim-emulation
 ;; Version: 0.1
-;; Package-Requires: ((emacs "24.4") (evil "1.2.12"))
+;; Package-Requires: ((emacs "24.4") (evil "1.2.12") (ledger-mode "0"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
Hi Aaron, 

This PR fix the missing dependency on `ledger-mode` package.

As ledger-mode package does not declare any version in its headers we put 0
which means take any version in the ELPA repository.

Cheers,
syl20bnr